### PR TITLE
[97] Category and Subject models, with GET/POST

### DIFF
--- a/src/consts/models.js
+++ b/src/consts/models.js
@@ -12,7 +12,8 @@ const refs = {
   FINISHED_QUIZ: 'FinishedQuiz',
   ATTACHMENT: 'Attachment',
   QUESTION: 'Question',
-  RESOURCES_CATEGORY: 'ResourcesCategory'
+  RESOURCES_CATEGORY: 'ResourcesCategory',
+  CATEGORY: 'Category',
 }
 
 module.exports = refs

--- a/src/controllers/category.js
+++ b/src/controllers/category.js
@@ -1,0 +1,26 @@
+const categoryService = require('~/services/category')
+
+const getCategories = async (req, res) => {
+  const categories = await categoryService.getCategories()
+
+  res.status(200).json({
+    status: true,
+    data: categories
+  })
+}
+
+const createCategory = async (req, res) => {
+  const { name, appearance } = req.body
+
+  const newCategory = await categoryService.createCategory(name, appearance)
+
+  res.status(201).json({
+    status: true,
+    data: newCategory
+  })
+}
+
+module.exports = {
+  getCategories,
+  createCategory
+}

--- a/src/controllers/subject.js
+++ b/src/controllers/subject.js
@@ -1,0 +1,26 @@
+const subjectService = require('~/services/subject')
+
+const getSubjects = async (req, res) => {
+  const subjects = await subjectService.getSubjects()
+
+  res.status(200).json({
+    status: true,
+    data: subjects
+  })
+}
+
+const createSubject = async (req, res) => {
+  const { name, categoryId } = req.body
+
+  const newSubject = await subjectService.createSubject(name, categoryId)
+
+  res.status(201).json({
+    status: true,
+    data: newSubject
+  })
+}
+
+module.exports = {
+  getSubjects,
+  createSubject
+}

--- a/src/models/category.js
+++ b/src/models/category.js
@@ -1,0 +1,50 @@
+const { Schema, model } = require('mongoose')
+const { CATEGORY } = require('~/consts/models')
+
+const {
+  FIELD_CANNOT_BE_EMPTY,
+  FIELD_CANNOT_BE_SHORTER,
+  FIELD_CANNOT_BE_LONGER,
+} = require('~/consts/errors')
+
+const categorySchema = new Schema(
+  {
+    name: {
+      type: String,
+      required: [true, FIELD_CANNOT_BE_EMPTY('category name')],
+      unique: true,
+      trim: true,
+      minLength: [2, FIELD_CANNOT_BE_SHORTER('category name', 2)],
+      maxLength: [50, FIELD_CANNOT_BE_LONGER('category name', 50)]
+    },
+    appearance: {
+      icon: {
+        type: String,
+        default: 'default-icon.png' // TODO: change to default icon
+      },
+      color: {
+        type: String,
+        default: '#66C42C'
+      }
+    },
+    totalOffers: {
+      student: {
+        type: Number,
+        default: 0
+      },
+      tutor: {
+        type: Number,
+        default: 0
+      }
+    }
+  },
+  {
+    timestamps: true,
+    toJSON: { virtuals: true },
+    toObject: { virtuals: true },
+    versionKey: false,
+    id: false
+  }
+)
+
+module.exports = model(CATEGORY, categorySchema)

--- a/src/models/subject.js
+++ b/src/models/subject.js
@@ -1,0 +1,45 @@
+const { Schema, model } = require('mongoose')
+const { SUBJECT, CATEGORY } = require('~/consts/models')
+
+const {
+  FIELD_CANNOT_BE_EMPTY,
+  FIELD_CANNOT_BE_SHORTER,
+  FIELD_CANNOT_BE_LONGER,
+} = require('~/consts/errors')
+
+const subjectSchema = new Schema(
+  {
+    name: {
+      type: String,
+      required: [true, FIELD_CANNOT_BE_EMPTY('subject name')],
+      unique: true,
+      trim: true,
+      minLength: [2, FIELD_CANNOT_BE_SHORTER('subject name', 2)],
+      maxLength: [50, FIELD_CANNOT_BE_LONGER('subject name', 50)]
+    },
+    totalOffers: {
+      student: {
+        type: Number,
+        default: 0
+      },
+      tutor: {
+        type: Number,
+        default: 0
+      }
+    },
+    category: {
+      type: Schema.Types.ObjectId,
+      ref: CATEGORY,
+      required: [true, FIELD_CANNOT_BE_EMPTY('category')]
+    }
+  },
+  {
+    timestamps: true,
+    toJSON: { virtuals: true },
+    toObject: { virtuals: true },
+    versionKey: false,
+    id: false
+  }
+)
+
+module.exports = model(SUBJECT, subjectSchema)

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -53,6 +53,11 @@ const userSchema = new Schema(
     },
     photo: String,
     professionalSummary: String,
+    professionalStatus: {
+      type: String,
+      minLength: [1, FIELD_CANNOT_BE_SHORTER('professional status', 1)],
+      maxLength: [100, FIELD_CANNOT_BE_LONGER('professional status', 100)]
+    },
     mainSubjects: {
       student: {
         type: [Schema.Types.ObjectId],

--- a/src/routes/category.js
+++ b/src/routes/category.js
@@ -1,0 +1,16 @@
+const router = require('express').Router()
+
+const asyncWrapper = require('~/middlewares/asyncWrapper')
+const {
+  getCategories,
+  // createCategory
+} = require('~/controllers/category')
+
+// TODO add auth, isEntityValid, validationMiddleware middlewares
+// TODO generate swagger docs for these endpoints
+
+router.get('/', asyncWrapper(getCategories))
+// TODO uncomment to enable createCategory
+// router.post('/', asyncWrapper(createCategory))
+
+module.exports = router

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -8,6 +8,8 @@ const question = require('~/routes/question')
 const resourcesCategory = require('~/routes/resourcesCategory')
 const offer = require('~/routes/offer')
 const location = require('~/routes/location')
+const category = require('~/routes/category')
+const subject = require('~/routes/subject')
 
 router.use('/auth', auth)
 router.use('/users', user)
@@ -17,5 +19,7 @@ router.use('/questions', question)
 router.use('/resources-categories', resourcesCategory)
 router.use('/offers', offer)
 router.use('/location', location)
+router.use('/categories', category)
+router.use('/subjects', subject)
 
 module.exports = router

--- a/src/routes/subject.js
+++ b/src/routes/subject.js
@@ -1,0 +1,16 @@
+const router = require('express').Router()
+
+const asyncWrapper = require('~/middlewares/asyncWrapper')
+const {
+  getSubjects,
+  //createSubject
+} = require('~/controllers/subject')
+
+// TODO add auth, isEntityValid, validationMiddleware middlewares
+// TODO generate swagger docs for these endpoints
+
+router.get('/', asyncWrapper(getSubjects))
+// TODO uncomment to enable createSubject
+//router.post('/', asyncWrapper(createSubject))
+
+module.exports = router

--- a/src/services/category.js
+++ b/src/services/category.js
@@ -1,0 +1,17 @@
+const Category = require('~/models/category')
+
+class CategoryService {
+  async getCategories() {
+    return await Category.find()
+  }
+
+  async createCategory(name, appearance) {
+    const { icon, color } = appearance ?? {}
+    const newCategory = new Category({ name, appearance: { icon, color } })
+    return await newCategory.save()
+  }
+}
+
+const categoryService = new CategoryService()
+
+module.exports = categoryService

--- a/src/services/subject.js
+++ b/src/services/subject.js
@@ -1,0 +1,17 @@
+const Subject = require('~/models/subject')
+
+class SubjectService {
+  async getSubjects() {
+    return await Subject.find()
+  }
+
+  async createSubject(name, categoryId) {
+    const newSubject = new Subject({ name, category: categoryId })
+
+    return await newSubject.save()
+  }
+}
+
+const subjectService = new SubjectService()
+
+module.exports = subjectService


### PR DESCRIPTION
This PR brings only part of functionallity to unblock FE. The rest will be delivered in next PRs.

## Work done
- Created Category and Subject models with basic validation
- Created appropriate routes, controllers and services
- Currently only GET endpoints are exposed 

## How to use
To fetch all categories use `/categories`, same for subjects - `/subjects`